### PR TITLE
Add minimal explanation on what files_irods is about

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 files_irods
 ===========
+
+Plugin that allows Owncloud to see iRODS (http://irods.org/) volumes.
+
+This plugin is still in development, please have a look at the following pullrequest
+if you wish to contribute:
+
+https://github.com/owncloud/core/pull/6004
+
+INCF contributed to its development via a contract with OwnCloud Inc.


### PR DESCRIPTION
Still works for OwnCloud 7.

We might want to strip the 3rdparty folder for the `php-irods` package:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=748608
